### PR TITLE
Fix py/state unpickling

### DIFF
--- a/unpickler.js
+++ b/unpickler.js
@@ -216,7 +216,7 @@ define(['./util', './handlers', './tags'], function(util, handlers, tags) {
             var state = this._restore(obj[tags.STATE]);
             instance.__setstate__(state);
         } else {
-            instance = this._restore(obj[tags.STATE]);
+            instance = this._restore_object_instance_variables(obj[tags.STATE], instance);
         }
         return instance;
     };


### PR DESCRIPTION
Unpickling `py/state` entries was broken because the object prototype was lost during state restoration. This PR fixes it. Related to https://github.com/cuthbertLab/music21j/issues/13
